### PR TITLE
Development linking script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+cba_settings.sqf
+cScripts
+Data
+description.ext
+init.sqf
+initServer.sqf

--- a/Scripts/setupDevEnviroment.py
+++ b/Scripts/setupDevEnviroment.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import sys, os
+import argparse
+
+__version__ = 1.0
+
+# set projecty path
+scriptPath = os.path.realpath(__file__)
+scriptDir = os.path.dirname(scriptPath)
+rootDir = os.path.dirname(os.path.dirname(scriptPath))
+os.chdir(rootDir)
+
+def main():
+    # Handle argumets
+    parser = argparse.ArgumentParser(
+        prog='setupDevEnviroment',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='',
+        epilog=''
+    )
+    parser.add_argument('path',
+        help='Define the fullpath to the cScripts directory.'
+    )
+    parser.add_argument('--version', action='version', version='Author: Andreas Broström <andreas.brostrom.ce@gmail.com>\nScript version: {}'.format(__version__))
+
+    args = parser.parse_args()
+
+    # setting up linking
+    print('Setting up development enviroment...')
+
+    # Check if cscripts exist in side of given directory
+    print('Checking cScripts location \'{}\''.format(args.path))
+
+    cScriptsControllFiles = [
+        '\\cScripts',
+        '\\cScripts\\script_component.hpp',
+        '\\cScripts\\CavFnc\\cScripts_postInit.sqf',
+        '\\cScripts\\CavFnc\\functions\\script_component.hpp',
+        '\\description.ext',
+        '\\initServer.sqf'
+    ]
+    for c in cScriptsControllFiles:
+        if not os.path.exists('{}{}'.format(args.path,c)):
+            sys.exit('Error: No cScript could be detected within the given directory.')
+    print('cScripts location is valid...')
+
+    # Fetch files and aply blacklist
+    mission_list = os.listdir(rootDir)
+    blacklist_files = [
+        '.git',
+        '.github',
+        'Compositions',
+        'doc',
+        'release',
+        'resourses',
+        'tools',
+        '.editorconfig',
+        '.gitattributes',
+        '.gitignore',
+        '.gitmodules',
+        'LICENSE',
+        'README.md',
+        'Scripts',
+        'mission.sqm'
+    ]
+    for f in blacklist_files:
+        try:
+            mission_list.remove(f)
+        except:
+            pass
+    
+    # fetch cScript files and remove blacklisted
+    content = os.listdir(args.path)
+    for f in blacklist_files:
+        try:
+            content.remove(f)
+        except:
+            pass
+
+    for mission in mission_list:
+        print('\nSetting up dev links for {}'.format(mission))
+
+        #check if mission already have cScripts
+        if os.path.exists('{}\\{}\\cScripts'.format(rootDir,mission)):
+            print('cScripts already installed in this mission skipping...')
+            continue
+        if os.path.exists('{}\\{}\\description.ext'.format(rootDir,mission)):
+            print('description.ext already setup in this mission skipping...')
+            continue
+        if os.path.exists('{}\\{}\\init.sqf'.format(rootDir,mission)):
+            print('init.sqf already setup in this mission skipping...')
+            continue
+
+        for obj in content:
+            try:
+                os.symlink('{}\\{}'.format(args.path,obj), '{}\\{}\\{}'.format(rootDir,mission,obj))
+                print('Linking', '{}\\{}'.format(args.path,obj).ljust(62), '<===>'.ljust(8), '{}\\{}\\{}'.format(rootDir,mission,obj))
+                continue
+            except:
+                print('Warning: {} already exist for {} skipping...'.format(obj, mission))
+
+
+
+    #os.symlink(src, dst)
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This is a command line tool that create symbolic links between your cScripts repo and all the training missions.

To run the script navigate to the training mission `Scripts` folder via a terminal and provide your path cScripts. 
Example:
```cmd
> cd /d D:\Arma3Mission\trainingMissions\Scripts
> setupDevEnviroment.exe D:\Arma3Mission\scriptFramworks\cScripts.VR
```

```
usage: setupDevEnviroment [-h] [--version] path

positional arguments:
  path        Define the fullpath to the cScripts directory.

optional arguments:
  -h, --help  show this help message and exit
  --version   show program's version number and exit
```

For this script to work cScripts init.sqf and description.ext needs to be removed and replaced with a `setup.json`
See mission [7CAV_2NDPLATOON_TRAINING_DEVBUILD.Malden](https://github.com/7Cav/7thCavalry_Training_Missions/tree/Develop/7CAV_2NDPLATOON_TRAINING_DEVBUILD.Malden) for correct setup.

(Merge when missions are ready)

Fixes #8
